### PR TITLE
 Added Codable support for Node.

### DIFF
--- a/Graph.xcodeproj/project.pbxproj
+++ b/Graph.xcodeproj/project.pbxproj
@@ -180,6 +180,12 @@
 		96F1DC7A1D64DDCF0025F925 /* ManagedActionGroup.swift in Headers */ = {isa = PBXBuildFile; fileRef = 9686720F1D3BEA8F000CD904 /* ManagedActionGroup.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		9D1BF321211FAB8600939295 /* NamedManagedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1BF320211FAB8600939295 /* NamedManagedObject.swift */; };
 		9D1BF3242120654800939295 /* NamedManagedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1BF320211FAB8600939295 /* NamedManagedObject.swift */; };
+		9D77130021238B3500E8D3AE /* EntityCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7712FF21238B3500E8D3AE /* EntityCodableTests.swift */; };
+		9D77130121238B3500E8D3AE /* EntityCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7712FF21238B3500E8D3AE /* EntityCodableTests.swift */; };
+		9D77130321238E3600E8D3AE /* RelationshipCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D77130221238E3600E8D3AE /* RelationshipCodableTests.swift */; };
+		9D77130421238E3600E8D3AE /* RelationshipCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D77130221238E3600E8D3AE /* RelationshipCodableTests.swift */; };
+		9D77130621238E4400E8D3AE /* ActionCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D77130521238E4400E8D3AE /* ActionCodableTests.swift */; };
+		9D77130721238E4400E8D3AE /* ActionCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D77130521238E4400E8D3AE /* ActionCodableTests.swift */; };
 		9DCA6216211A47DA00E4A4B7 /* GraphJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCA6215211A47DA00E4A4B7 /* GraphJSONTests.swift */; };
 		9DCA6217211A47DA00E4A4B7 /* GraphJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCA6215211A47DA00E4A4B7 /* GraphJSONTests.swift */; };
 		9DD27AB321233E6500452EB4 /* AnyCodeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD27AB221233E6500452EB4 /* AnyCodeable.swift */; };
@@ -267,6 +273,9 @@
 		96E3C45B1D3AE4F00086A024 /* Coordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		96E3C45E1D3AE50E0086A024 /* Context.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
 		9D1BF320211FAB8600939295 /* NamedManagedObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedManagedObject.swift; sourceTree = "<group>"; };
+		9D7712FF21238B3500E8D3AE /* EntityCodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EntityCodableTests.swift; sourceTree = "<group>"; };
+		9D77130221238E3600E8D3AE /* RelationshipCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipCodableTests.swift; sourceTree = "<group>"; };
+		9D77130521238E4400E8D3AE /* ActionCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionCodableTests.swift; sourceTree = "<group>"; };
 		9DCA6215211A47DA00E4A4B7 /* GraphJSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphJSONTests.swift; sourceTree = "<group>"; };
 		9DD27AB221233E6500452EB4 /* AnyCodeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodeable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -323,6 +332,7 @@
 				964119542111039E0057137A /* ActionTagTests.swift */,
 				964119442111039D0057137A /* ActionTests.swift */,
 				964119572111039E0057137A /* ActionThreadTests.swift */,
+				9D77130521238E4400E8D3AE /* ActionCodableTests.swift */,
 			);
 			path = Action;
 			sourceTree = "<group>";
@@ -337,6 +347,7 @@
 				964119562111039E0057137A /* EntityTagTests.swift */,
 				964119432111039D0057137A /* EntityTests.swift */,
 				964119462111039D0057137A /* EntityThreadTests.swift */,
+				9D7712FF21238B3500E8D3AE /* EntityCodableTests.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -351,6 +362,7 @@
 				964119482111039E0057137A /* RelationshipTagTests.swift */,
 				9641194A2111039E0057137A /* RelationshipTests.swift */,
 				964119492111039E0057137A /* RelationshipThreadTests.swift */,
+				9D77130221238E3600E8D3AE /* RelationshipCodableTests.swift */,
 			);
 			path = Relationship;
 			sourceTree = "<group>";
@@ -791,6 +803,8 @@
 				964119692111039E0057137A /* ActionPropertyTests.swift in Sources */,
 				9641197F2111039E0057137A /* EntityTagTests.swift in Sources */,
 				964119772111039E0057137A /* EntityPropertyStressTests.swift in Sources */,
+				9D77130321238E3600E8D3AE /* RelationshipCodableTests.swift in Sources */,
+				9D77130021238B3500E8D3AE /* EntityCodableTests.swift in Sources */,
 				964119792111039E0057137A /* ActionGroupTests.swift in Sources */,
 				9DCA6216211A47DA00E4A4B7 /* GraphJSONTests.swift in Sources */,
 				964119732111039E0057137A /* RelationshipSearchTests.swift in Sources */,
@@ -802,6 +816,7 @@
 				9641195B2111039E0057137A /* ActionTests.swift in Sources */,
 				964119812111039E0057137A /* ActionThreadTests.swift in Sources */,
 				9641196F2111039E0057137A /* EntityGroupTests.swift in Sources */,
+				9D77130621238E4400E8D3AE /* ActionCodableTests.swift in Sources */,
 				9641195F2111039E0057137A /* EntityThreadTests.swift in Sources */,
 				964119652111039E0057137A /* RelationshipThreadTests.swift in Sources */,
 				9641197D2111039E0057137A /* EntityPropertyTests.swift in Sources */,
@@ -861,6 +876,8 @@
 				9641196A2111039E0057137A /* ActionPropertyTests.swift in Sources */,
 				964119802111039E0057137A /* EntityTagTests.swift in Sources */,
 				964119782111039E0057137A /* EntityPropertyStressTests.swift in Sources */,
+				9D77130421238E3600E8D3AE /* RelationshipCodableTests.swift in Sources */,
+				9D77130121238B3500E8D3AE /* EntityCodableTests.swift in Sources */,
 				9641197A2111039E0057137A /* ActionGroupTests.swift in Sources */,
 				9DCA6217211A47DA00E4A4B7 /* GraphJSONTests.swift in Sources */,
 				964119742111039E0057137A /* RelationshipSearchTests.swift in Sources */,
@@ -872,6 +889,7 @@
 				9641195C2111039E0057137A /* ActionTests.swift in Sources */,
 				964119822111039E0057137A /* ActionThreadTests.swift in Sources */,
 				964119702111039E0057137A /* EntityGroupTests.swift in Sources */,
+				9D77130721238E4400E8D3AE /* ActionCodableTests.swift in Sources */,
 				964119602111039E0057137A /* EntityThreadTests.swift in Sources */,
 				964119662111039E0057137A /* RelationshipThreadTests.swift in Sources */,
 				9641197E2111039E0057137A /* EntityPropertyTests.swift in Sources */,

--- a/Graph.xcodeproj/project.pbxproj
+++ b/Graph.xcodeproj/project.pbxproj
@@ -182,6 +182,8 @@
 		9D1BF3242120654800939295 /* NamedManagedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1BF320211FAB8600939295 /* NamedManagedObject.swift */; };
 		9DCA6216211A47DA00E4A4B7 /* GraphJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCA6215211A47DA00E4A4B7 /* GraphJSONTests.swift */; };
 		9DCA6217211A47DA00E4A4B7 /* GraphJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCA6215211A47DA00E4A4B7 /* GraphJSONTests.swift */; };
+		9DD27AB321233E6500452EB4 /* AnyCodeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD27AB221233E6500452EB4 /* AnyCodeable.swift */; };
+		9DD27AB421233E6500452EB4 /* AnyCodeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD27AB221233E6500452EB4 /* AnyCodeable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -266,6 +268,7 @@
 		96E3C45E1D3AE50E0086A024 /* Context.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
 		9D1BF320211FAB8600939295 /* NamedManagedObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedManagedObject.swift; sourceTree = "<group>"; };
 		9DCA6215211A47DA00E4A4B7 /* GraphJSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphJSONTests.swift; sourceTree = "<group>"; };
+		9DD27AB221233E6500452EB4 /* AnyCodeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodeable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -461,6 +464,7 @@
 				96E3C4551D3AD6930086A024 /* Storage.swift */,
 				96E3C4581D3AD6B00086A024 /* Search.swift */,
 				96E3C4521D3AD5CA0086A024 /* Watch.swift */,
+				9DD27AB221233E6500452EB4 /* AnyCodeable.swift */,
 			);
 			name = Graph;
 			sourceTree = "<group>";
@@ -762,6 +766,7 @@
 				96E3C4531D3AD5CA0086A024 /* Watch.swift in Sources */,
 				96E3C4421D3AC7E40086A024 /* Relationship.swift in Sources */,
 				96E3C4561D3AD6930086A024 /* Storage.swift in Sources */,
+				9DD27AB321233E6500452EB4 /* AnyCodeable.swift in Sources */,
 				9686720D1D3BEA50000CD904 /* ManagedRelationshipGroup.swift in Sources */,
 				968672071D3BE6C2000CD904 /* ManagedGroup.swift in Sources */,
 				9686720A1D3BE9BA000CD904 /* ManagedEntityGroup.swift in Sources */,
@@ -831,6 +836,7 @@
 				96E3C44A1D3AC7E50086A024 /* Relationship.swift in Sources */,
 				96E3C4571D3AD6930086A024 /* Storage.swift in Sources */,
 				9686720E1D3BEA50000CD904 /* ManagedRelationshipGroup.swift in Sources */,
+				9DD27AB421233E6500452EB4 /* AnyCodeable.swift in Sources */,
 				968672081D3BE6C2000CD904 /* ManagedGroup.swift in Sources */,
 				9686720B1D3BE9BA000CD904 /* ManagedEntityGroup.swift in Sources */,
 				96E3C4511D3AC7E50086A024 /* ManagedActionProperty.swift in Sources */,

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -33,11 +33,8 @@ import Foundation
 @objc(Action)
 public class Action: Node {
   /// A reference to the managedNode.
-  internal let managedNode: ManagedAction
-  
-  /// A reference to the managedNode for base node class.
-  internal override var node: ManagedNode {
-    return managedNode
+  internal var managedNode: ManagedAction {
+    return node as! ManagedAction
   }
   
   public override var description: String {
@@ -63,51 +60,17 @@ public class Action: Node {
     } ?? []
   }
   
+  /// Generic creation of the managed node type.
+  override class func createNode(_ type: String, in context: NSManagedObjectContext) -> ManagedNode {
+    return ManagedAction(type, managedObjectContext: context)
+  }
+  
   /**
    Initializer that accepts a ManagedAction.
    - Parameter managedNode: A reference to a ManagedAction.
    */
-  internal init(managedNode: ManagedAction) {
-    self.managedNode = managedNode
-  }
-  
-  /**
-   Initializer that accepts a type and graph. The graph
-   indicates which graph to save to.
-   - Parameter _ type: A reference to a type.
-   - Parameter graph: A reference to a Graph instance by name.
-   */
-  @nonobjc
-  public convenience init(_ type: String, graph: String) {
-    let context = Graph(name: graph).managedObjectContext
-    var managedNode: ManagedAction?
-    context?.performAndWait {
-      managedNode = ManagedAction(type, managedObjectContext: context!)
-    }
-    self.init(managedNode: managedNode!)
-  }
-  
-  /**
-   Initializer that accepts a type and graph. The graph
-   indicates which graph to save to.
-   - Parameter _ type: A reference to a type.
-   - Parameter graph: A reference to a Graph instance.
-   */
-  public convenience init(_ type: String, graph: Graph) {
-    let context = graph.managedObjectContext
-    var managedNode: ManagedAction?
-    context?.performAndWait {
-      managedNode = ManagedAction(type, managedObjectContext: context!)
-    }
-    self.init(managedNode: managedNode!)
-  }
-  
-  /**
-   Initializer that accepts a type value.
-   - Parameter _ type: A reference to a type.
-   */
-  public convenience init(_ type: String) {
-    self.init(type, graph: GraphStoreDescription.name)
+  required init(managedNode: ManagedNode) {
+    super.init(managedNode: managedNode)
   }
   
   /**

--- a/Sources/AnyCodeable.swift
+++ b/Sources/AnyCodeable.swift
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2015 - 2018, Daniel Dahan and CosmicMind, Inc. <http://cosmicmind.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  *  Neither the name of CosmicMind nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Foundation
+
+public struct AnyCodable: Codable {
+  public let value: Encodable
+  public static var codables: [Codable.Type] = [
+    String.self,
+    Double.self,
+    Bool.self,
+    Date.self,
+    Data.self,
+    Int.self,
+    URL.self
+  ]
+  
+  /**
+   Recursively creates AnyCodable instance.
+   - Parameter _ value: Any value.
+   */
+  public init?(_ value: Any) {
+    if let array = value as? [Any] {
+      self.value = array.map { AnyCodable($0) }
+      return
+    }
+    
+    if let dictionary = value as? [String: Any] {
+      self.value = dictionary.reduce(into: [String: AnyCodable]()) {
+        $0[$1.key] = AnyCodable($1.value)
+      }
+      return
+    }
+    
+    /// value as? Encodable always fails.
+    /// So we cast to the supported types and take the Encodable value.
+    for c in AnyCodable.codables {
+      if let v = c.casting(value) {
+        self.value = v
+        return
+      }
+    }
+    
+    return nil
+  }
+  
+  /**
+   Creates a new instance by decoding from the given decoder.
+   - Parameter decoder: The decoder to read data from.
+  */
+  public init(from decoder: Decoder) throws {
+    /// Trying to decode from supporting types.
+    for c in AnyCodable.codables {
+      if let v = try? c.init(from: decoder) {
+        value = v
+        return
+      }
+    }
+    
+    if let v = try? [AnyCodable].init(from: decoder) {
+      value = v
+      return
+    }
+    
+    if let v = try? [String: AnyCodable].init(from: decoder) {
+      value = v
+      return
+    }
+    
+    
+    throw DecodingError.dataCorruptedError(in: try decoder.unkeyedContainer(), debugDescription: "[AnyCodable: Failed to decode]")
+  }
+  
+  /**
+   Encodes this value into the given encoder.
+   - Parameter encoder: The encoder to write data to.
+   */
+  public func encode(to encoder: Encoder) throws {
+    /// https://stackoverflow.com/q/48658574/jsonencoders-dateencodingstrategy-not-working
+    var container = encoder.singleValueContainer()
+    try value.encode(to: &container)
+  }
+
+  /// Recursively unwraps any nested AnyCodable in the value.
+  public func unwrap() -> Any {
+    return AnyCodable.unwrap(self)
+  }
+}
+
+private extension AnyCodable {
+  /// Recursively unwraps any nested AnyCodable in the value.
+  static func unwrap(_ value: Any) -> Any {
+    if let v = value as? AnyCodable {
+      return unwrap(v.value)
+    }
+    
+    if let v = value as? [AnyCodable] {
+      return v.map { unwrap($0.value) }
+    }
+    
+    if let v = value as? [String: AnyCodable] {
+      return v.reduce(into: [String: Any]()) {
+        $0[$1.key] = unwrap($1.value)
+      }
+    }
+    
+    return value
+  }
+}
+
+private extension Encodable {
+  /**
+   Casts a value to itself.
+   - Parameter _ value: A value to be cast.
+   - Returns: Casted value, nil if cast failed.
+   */
+  static func casting(_ value: Any) -> Self? {
+    return value as? Self
+  }
+  
+  
+  func encode(to container: inout SingleValueEncodingContainer) throws {
+    try container.encode(self)
+  }
+}

--- a/Sources/Entity.swift
+++ b/Sources/Entity.swift
@@ -33,12 +33,10 @@ import Foundation
 @objc(Entity)
 public class Entity: Node {
   /// A reference to the managedNode.
-  internal let managedNode: ManagedEntity
-  
-  /// A reference to the managedNode for base class.
-  override var node: ManagedNode {
-    return managedNode
+  internal var managedNode: ManagedEntity {
+    return node as! ManagedEntity
   }
+
   
   /// A string representation of the Entity.
   public override var description: String {
@@ -139,52 +137,18 @@ public class Entity: Node {
       $0.relationshipObjectSet.map { Relationship(managedNode: $0) }
     }
   }
-  
-  /**
-   Initializer that accepts a ManagedEntity.
-   - Parameter managedNode: A reference to a ManagedEntity.
-   */
-  internal init(managedNode: ManagedEntity) {
-    self.managedNode = managedNode
+
+  /// Generic creation of the managed node type.
+  override class func createNode(_ type: String, in context: NSManagedObjectContext) -> ManagedNode {
+    return ManagedEntity(type, managedObjectContext: context)
   }
   
   /**
-   Initializer that accepts a type and graph. The graph
-   indicates which graph to save to.
-   - Parameter _ type: A reference to a type.
-   - Parameter graph: A reference to a Graph instance by name.
+   Initializer that accepts a ManagedAction.
+   - Parameter managedNode: A reference to a ManagedAction.
    */
-  @nonobjc
-  public convenience init(_ type: String, graph: String) {
-    let context = Graph(name: graph).managedObjectContext
-    var managedNode: ManagedEntity?
-    context?.performAndWait {
-      managedNode = ManagedEntity(type, managedObjectContext: context!)
-    }
-    self.init(managedNode: managedNode!)
-  }
-  
-  /**
-   Initializer that accepts a type and graph. The graph
-   indicates which graph to save to.
-   - Parameter _ type: A reference to a type.
-   - Parameter graph: A reference to a Graph instance.
-   */
-  public convenience init(_ type: String, graph: Graph) {
-    let context = graph.managedObjectContext
-    var managedNode: ManagedEntity?
-    context?.performAndWait {
-      managedNode = ManagedEntity(type, managedObjectContext: context!)
-    }
-    self.init(managedNode: managedNode!)
-  }
-  
-  /**
-   Initializer that accepts a type value.
-   - Parameter _ type: A reference to a type.
-   */
-  public convenience init(_ type: String) {
-    self.init(type, graph: GraphStoreDescription.name)
+  required init(managedNode: ManagedNode) {
+    super.init(managedNode: managedNode)
   }
   
   /**

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -38,8 +38,49 @@ public enum NodeClass: Int {
 
 @dynamicMemberLookup
 public class Node: NSObject {
-  /// A reference to the managedNode for base node class.
-  internal var node: ManagedNode {
+  /// A reference to managed node.
+  let node: ManagedNode
+  
+  /**
+   Initializer that accepts a ManagedAction.
+   - Parameter managedNode: A reference to a ManagedAction.
+   */
+  required init(managedNode: ManagedNode) {
+    node = managedNode
+  }
+  
+  /**
+   Initializer that accepts a type and graph. The graph
+   indicates which graph to save to.
+   - Parameter _ type: A reference to a type.
+   - Parameter graph: A reference to a Graph instance by name.
+   */
+  @nonobjc
+  public convenience init(_ type: String, graph: String) {
+    self.init(type, graph: Graph(name: graph))
+  }
+  
+  /**
+   Initializer that accepts a type and graph. The graph
+   indicates which graph to save to.
+   - Parameter _ type: A reference to a type.
+   - Parameter graph: A reference to a Graph instance.
+   */
+  public convenience init(_ type: String, graph: Graph) {
+    let node = Swift.type(of: self).createNode(type, in: graph.managedObjectContext)
+    self.init(managedNode: node)
+  }
+  
+  /**
+   Initializer that accepts a type value.
+   - Parameter _ type: A reference to a type.
+   */
+  public convenience init(_ type: String) {
+    self.init(type, graph: GraphStoreDescription.name)
+  }
+  
+  /// Generic creation of the managed node type.
+  class func createNode(_ type: String, in context: NSManagedObjectContext) -> ManagedNode {
     fatalError("Must be implemented by subclasses")
   }
   

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -36,10 +36,72 @@ public enum NodeClass: Int {
   case action = 3
 }
 
+
+extension CodingUserInfoKey {
+  /// CodingUserInfoKey for passing Graph instance or name to decoding context.
+  public static let graph = CodingUserInfoKey(rawValue: "graph")!
+}
+
+
 @dynamicMemberLookup
-public class Node: NSObject {
+public class Node: NSObject, Codable {
   /// A reference to managed node.
   let node: ManagedNode
+  
+  /// CodingKeys for encoding and decoding
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case tags
+    case groups
+    case properties
+    case createdDate
+  }
+  
+  /**
+   Encodes this value into the given encoder.
+   - Parameter encoder: The encoder to write data to.
+   */
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(type, forKey: .type)
+    try container.encode(tags, forKey: .tags)
+    try container.encode(groups, forKey: .groups)
+    try container.encode(AnyCodable(properties), forKey: .properties)
+    try container.encode(createdDate, forKey: .createdDate)
+  }
+  
+  /**
+   Creates a new instance by decoding from the given decoder.
+   - Parameter decoder: The decoder to read data from.
+   */
+  public required convenience init(from decoder: Decoder) throws {
+    let graphInfo = decoder.userInfo[.graph]
+    let graph = graphInfo as? Graph ?? Graph(name: graphInfo as? String ?? GraphStoreDescription.name)
+    
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try values.decode(String.self, forKey: .type)
+    let tags = try values.decodeIfPresent([String].self, forKey: .tags) ?? []
+    let groups = try values.decodeIfPresent([String].self, forKey: .groups) ?? []
+    let properties = try values.decodeIfPresent(AnyCodable.self, forKey: .properties)?.unwrap()
+    let createdDate = try values.decodeIfPresent(Date.self, forKey: .createdDate) ?? Date()
+    
+    let node = Swift.type(of: self).createNode(type, graph: graph)
+    self.init(managedNode: node)
+    node.add(tags: tags)
+    node.add(to: groups)
+    
+    node.performAndWait { node in
+      node.createdDate = createdDate
+    }
+    
+    guard let p = properties as? [String: Any] else {
+      return
+    }
+    
+    p.forEach {
+      self[$0.key] = $0.value
+    }
+  }
   
   /**
    Initializer that accepts a ManagedAction.
@@ -67,7 +129,7 @@ public class Node: NSObject {
    - Parameter graph: A reference to a Graph instance.
    */
   public convenience init(_ type: String, graph: Graph) {
-    let node = Swift.type(of: self).createNode(type, in: graph.managedObjectContext)
+    let node = Swift.type(of: self).createNode(type, graph: graph)
     self.init(managedNode: node)
   }
   
@@ -82,6 +144,14 @@ public class Node: NSObject {
   /// Generic creation of the managed node type.
   class func createNode(_ type: String, in context: NSManagedObjectContext) -> ManagedNode {
     fatalError("Must be implemented by subclasses")
+  }
+  
+  private class func createNode(_ type: String, graph: Graph) -> ManagedNode {
+    var node: ManagedNode!
+    graph.managedObjectContext.performAndWait {
+      node = createNode(type, in: graph.managedObjectContext)
+    }
+    return node
   }
   
   /// A reference to the type.

--- a/Sources/Relationship.swift
+++ b/Sources/Relationship.swift
@@ -33,13 +33,10 @@ import Foundation
 @objc(Relationship)
 public class Relationship: Node {
   /// A reference to the managedNode.
-  internal let managedNode: ManagedRelationship
-  
-  /// A reference to the managedNode for base node class.
-  internal override var node: ManagedNode {
-    return managedNode
+  internal var managedNode: ManagedRelationship {
+    return node as! ManagedRelationship
   }
-  
+
   public override var description: String {
     return "[nodeClass: \(nodeClass), id: \(id), type: \(type), tags: \(tags), groups: \(groups), properties: \(properties), subject: \(String(describing: subject)), object: \(String(describing: object)), createdDate: \(createdDate)]"
   }
@@ -91,51 +88,17 @@ public class Relationship: Node {
     }
   }
   
-  /**
-   Initializer that accepts a ManagedRelationship.
-   - Parameter managedNode: A reference to a ManagedRelationship.
-   */
-  internal init(managedNode: ManagedRelationship) {
-    self.managedNode = managedNode
+  /// Generic creation of the managed node type.
+  override class func createNode(_ type: String, in context: NSManagedObjectContext) -> ManagedNode {
+    return ManagedRelationship(type, managedObjectContext: context)
   }
   
   /**
-   Initializer that accepts a type and graph. The graph
-   indicates which graph to save to.
-   - Parameter _ type: A reference to a type.
-   - Parameter graph: A reference to a Graph instance by name.
+   Initializer that accepts a ManagedAction.
+   - Parameter managedNode: A reference to a ManagedAction.
    */
-  @nonobjc
-  public convenience init(_ type: String, graph: String) {
-    let context = Graph(name: graph).managedObjectContext
-    var managedNode: ManagedRelationship?
-    context?.performAndWait {
-      managedNode = ManagedRelationship(type, managedObjectContext: context!)
-    }
-    self.init(managedNode: managedNode!)
-  }
-  
-  /**
-   Initializer that accepts a type and graph. The graph
-   indicates which graph to save to.
-   - Parameter _ type: A reference to a type.
-   - Parameter graph: A reference to a Graph instance.
-   */
-  public convenience init(_ type: String, graph: Graph) {
-    let context = graph.managedObjectContext
-    var managedNode: ManagedRelationship?
-    context?.performAndWait {
-      managedNode = ManagedRelationship(type, managedObjectContext: context!)
-    }
-    self.init(managedNode: managedNode!)
-  }
-  
-  /**
-   Initializer that accepts a type value.
-   - Parameter _ type: A reference to a type.
-   */
-  public convenience init(_ type: String) {
-    self.init(type, graph: GraphStoreDescription.name)
+  required init(managedNode: ManagedNode) {
+    super.init(managedNode: managedNode)
   }
     
   /**

--- a/Tests/Action/ActionCodableTests.swift
+++ b/Tests/Action/ActionCodableTests.swift
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015 - 2018, Daniel Dahan and CosmicMind, Inc. <http://cosmicmind.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of CosmicMind nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+import Foundation
+@testable import Graph
+
+class ActionCodableTests: XCTestCase {
+  let array: [Any] = [-1, "2", [3, "4"], Decimal(12.34)]
+  
+  func testEncoder() {
+    let action = Action("User", graph: "CodableGraph")
+    action.name = "Orkhan"
+    action.age = 20
+    action.url = URL(string: "http://cosmicmind.com")!
+    action.array = array
+    action.dictionary = ["key": array]
+    
+    action.add(tags: ["Swift", "iOS"])
+    action.add(to: ["Programming", "Religion"])
+    
+    guard let data = try? JSONEncoder().encode(action) else {
+      XCTFail("[EntityCodableTests Error: Encoder failed to encode.]")
+      return
+    }
+    
+    guard let json = GraphJSON.parse(data) else {
+      XCTFail("[EntityCodableTests Error: Failed to create GraphJSON.]")
+      return
+    }
+    
+    XCTAssertEqual(json.type.asString, "User")
+    XCTAssertEqual((json.tags.object as? [String]).map { Set($0) }, Set(["Swift", "iOS"]))
+    XCTAssertEqual((json.groups.object as? [String]).map { Set($0) }, Set(["Programming", "Religion"]))
+    XCTAssertEqual(json.properties.name.asString, "Orkhan")
+    XCTAssertEqual(json.properties.age.asInt, 20)
+    XCTAssertEqual(json.properties.url.asString, "http://cosmicmind.com")
+    XCTAssert((json.properties.array.object as? NSArray)?.isEqual(to: array) == true)
+    XCTAssert((json.properties.dictionary.object as? NSDictionary)?.isEqual(to: ["key": array]) == true)
+  }
+  
+  func testDecoder() {
+    let json = """
+      {
+        "type" : "User",
+        "groups" : [
+          "Programming",
+          "Religion"
+        ],
+        "tags" : [
+          "Swift",
+          "iOS"
+        ],
+        "properties" : {
+          "age" : 20,
+          "name" : "Orkhan",
+          "array": [-1, "2", [3, "4"], 12.34],
+          "dictionary": { "key": [-1, "2", [3, "4"], 12.34] }
+        }
+      }
+      """
+    
+    guard let data = json.data(using: .utf8) else {
+      XCTFail("[EntityCodableTests Error: Failed to create Data from json string.]")
+      return
+    }
+    let decoder = JSONDecoder()
+    decoder.userInfo[.graph] = "CodableGraph"
+    guard let action = try? decoder.decode(Action.self, from: data) else {
+      XCTFail("[EntityCodableTests Error: Decoder failed to decode.]")
+      return
+    }
+    
+    XCTAssertEqual(action.type, "User")
+    XCTAssertTrue(action.has(tags: ["iOS", "Swift"]))
+    XCTAssertTrue(action.member(of: ["Programming", "Religion"]))
+    XCTAssertEqual(action.name as? String, "Orkhan")
+    XCTAssertEqual(action.age as? Int, 20)
+    XCTAssert((action.array as? NSArray)?.isEqual(to: array) == true)
+    XCTAssert((action.dictionary as? NSDictionary)?.isEqual(to: ["key": array]) == true)
+  }
+}

--- a/Tests/Entity/EntityCodableTests.swift
+++ b/Tests/Entity/EntityCodableTests.swift
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015 - 2018, Daniel Dahan and CosmicMind, Inc. <http://cosmicmind.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of CosmicMind nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+import Foundation
+@testable import Graph
+
+class EntityCodableTests: XCTestCase {
+  let array: [Any] = [-1, "2", [3, "4"], Decimal(12.34)]
+  
+  func testEncoder() {
+    let entity = Entity("User", graph: "CodableGraph")
+    entity.name = "Orkhan"
+    entity.age = 20
+    entity.url = URL(string: "http://cosmicmind.com")!
+    entity.array = array
+    entity.dictionary = ["key": array]
+    
+    entity.add(tags: ["Swift", "iOS"])
+    entity.add(to: ["Programming", "Religion"])
+    
+    guard let data = try? JSONEncoder().encode(entity) else {
+      XCTFail("[EntityCodableTests Error: Encoder failed to encode.]")
+      return
+    }
+    
+    guard let json = GraphJSON.parse(data) else {
+      XCTFail("[EntityCodableTests Error: Failed to create GraphJSON.]")
+      return
+    }
+    
+    XCTAssertEqual(json.type.asString, "User")
+    XCTAssertEqual((json.tags.object as? [String]).map { Set($0) }, Set(["Swift", "iOS"]))
+    XCTAssertEqual((json.groups.object as? [String]).map { Set($0) }, Set(["Programming", "Religion"]))
+    XCTAssertEqual(json.properties.name.asString, "Orkhan")
+    XCTAssertEqual(json.properties.age.asInt, 20)
+    XCTAssertEqual(json.properties.url.asString, "http://cosmicmind.com")
+    XCTAssert((json.properties.array.object as? NSArray)?.isEqual(to: array) == true)
+    XCTAssert((json.properties.dictionary.object as? NSDictionary)?.isEqual(to: ["key": array]) == true)
+  }
+  
+  func testDecoder() {
+    let json = """
+      {
+        "type" : "User",
+        "groups" : [
+          "Programming",
+          "Religion"
+        ],
+        "tags" : [
+          "Swift",
+          "iOS"
+        ],
+        "properties" : {
+          "age" : 20,
+          "name" : "Orkhan",
+          "array": [-1, "2", [3, "4"], 12.34],
+          "dictionary": { "key": [-1, "2", [3, "4"], 12.34] }
+        }
+      }
+      """
+    
+    guard let data = json.data(using: .utf8) else {
+      XCTFail("[EntityCodableTests Error: Failed to create Data from json string.]")
+      return
+    }
+    let decoder = JSONDecoder()
+    decoder.userInfo[.graph] = "CodableGraph"
+    guard let entity = try? decoder.decode(Entity.self, from: data) else {
+      XCTFail("[EntityCodableTests Error: Decoder failed to decode.]")
+      return
+    }
+    
+    XCTAssertEqual(entity.type, "User")
+    XCTAssertTrue(entity.has(tags: ["iOS", "Swift"]))
+    XCTAssertTrue(entity.member(of: ["Programming", "Religion"]))
+    XCTAssertEqual(entity.name as? String, "Orkhan")
+    XCTAssertEqual(entity.age as? Int, 20)
+    XCTAssert((entity.array as? NSArray)?.isEqual(to: array) == true)
+    XCTAssert((entity.dictionary as? NSDictionary)?.isEqual(to: ["key": array]) == true)
+  }
+}

--- a/Tests/Relationship/RelationshipCodableTests.swift
+++ b/Tests/Relationship/RelationshipCodableTests.swift
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015 - 2018, Daniel Dahan and CosmicMind, Inc. <http://cosmicmind.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of CosmicMind nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+import Foundation
+@testable import Graph
+
+class RelationshipCodableTests: XCTestCase {
+  let array: [Any] = [-1, "2", [3, "4"], Decimal(12.34)]
+  
+  func testEncoder() {
+    let relationship = Relationship("User", graph: "CodableGraph")
+    relationship.name = "Orkhan"
+    relationship.age = 20
+    relationship.url = URL(string: "http://cosmicmind.com")!
+    relationship.array = array
+    relationship.dictionary = ["key": array]
+    
+    relationship.add(tags: ["Swift", "iOS"])
+    relationship.add(to: ["Programming", "Religion"])
+      
+    guard let data = try? JSONEncoder().encode(relationship) else {
+      XCTFail("[EntityCodableTests Error: Encoder failed to encode.]")
+      return
+    }
+    
+    guard let json = GraphJSON.parse(data) else {
+      XCTFail("[EntityCodableTests Error: Failed to create GraphJSON.]")
+      return
+    }
+    
+    XCTAssertEqual(json.type.asString, "User")
+    XCTAssertEqual((json.tags.object as? [String]).map { Set($0) }, Set(["Swift", "iOS"]))
+    XCTAssertEqual((json.groups.object as? [String]).map { Set($0) }, Set(["Programming", "Religion"]))
+    XCTAssertEqual(json.properties.name.asString, "Orkhan")
+    XCTAssertEqual(json.properties.age.asInt, 20)
+    XCTAssertEqual(json.properties.url.asString, "http://cosmicmind.com")
+    XCTAssert((json.properties.array.object as? NSArray)?.isEqual(to: array) == true)
+    XCTAssert((json.properties.dictionary.object as? NSDictionary)?.isEqual(to: ["key": array]) == true)
+  }
+  
+  func testDecoder() {
+    let json = """
+      {
+        "type" : "User",
+        "groups" : [
+          "Programming",
+          "Religion"
+        ],
+        "tags" : [
+          "Swift",
+          "iOS"
+        ],
+        "properties" : {
+          "age" : 20,
+          "name" : "Orkhan",
+          "array": [-1, "2", [3, "4"], 12.34],
+          "dictionary": { "key": [-1, "2", [3, "4"], 12.34] }
+        }
+      }
+      """
+    
+    guard let data = json.data(using: .utf8) else {
+      XCTFail("[EntityCodableTests Error: Failed to create Data from json string.]")
+      return
+    }
+    let decoder = JSONDecoder()
+    decoder.userInfo[.graph] = "CodableGraph"
+    guard let relationship = try? decoder.decode(Relationship.self, from: data) else {
+      XCTFail("[EntityCodableTests Error: Decoder failed to decode.]")
+      return
+    }
+    
+    XCTAssertEqual(relationship.type, "User")
+    XCTAssertTrue(relationship.has(tags: ["iOS", "Swift"]))
+    XCTAssertTrue(relationship.member(of: ["Programming", "Religion"]))
+    XCTAssertEqual(relationship.name as? String, "Orkhan")
+    XCTAssertEqual(relationship.age as? Int, 20)
+    XCTAssert((relationship.array as? NSArray)?.isEqual(to: array) == true)
+    XCTAssert((relationship.dictionary as? NSDictionary)?.isEqual(to: ["key": array]) == true)
+  }
+}


### PR DESCRIPTION
 Added Codable support for `Entity`, `Relationship` and `Actions`. #144 
Compiles successfully:
```swift
struct CodableGraph: Codable {
  var entity: Entity
  var relationship: Relationship
  var action: Relationship
}
```


Encoding:
```swift
let entity = Entity("User")
entity.name = "Orkhan"
entity.age = 20
entity.url = URL(string: "http://cosmicmind.com")!
entity.array = [-1, "2", Date(), Decimal(12.34)]
entity.dictionary = ["test": entity.array as? [Any]]

entity.add(tags: ["Swift", "iOS"])
entity.add(to: ["Programming", "Religion"])

let encoder = JSONEncoder()
encoder.outputFormatting = .prettyPrinted
encoder.dateEncodingStrategy = .iso8601
var data = try! encoder.encode(entity)
print(String(data: data, encoding: .utf8)!)
```
Prints:
```json
{
  "tags" : [
    "iOS",
    "Swift"
  ],
  "properties" : {
    "age" : 20,
    "array" : [
      -1,
      "2",
      "2018-08-14T21:24:15Z",
      12.34
    ],
    "name" : "Orkhan",
    "dictionary" : {
      "test" : [
        -1,
        "2",
        "2018-08-14T21:24:15Z",
        12.34
      ]
    },
    "url" : "http:\/\/cosmicmind.com"
  },
  "createdDate" : "2018-08-14T21:24:15Z",
  "type" : "User",
  "groups" : [
    "Programming",
    "Religion"
  ]
}
```

Decoding:
`Graph` (name or instance) to decode into can be provided via decoder's `userInfo`.
If not provided, will use default `Graph`.
```swift
let json = "{ type: \"User\" }"
let data = json.data(using: .utf8)!
let decoder = JSONDecoder()
decoder.userInfo[.graph] = "CodableGraph"
// decoder.userInfo[.graph] = Graph(name: "CodableGraph")
// decoder.userInfo[.graph] = nil // will use default Graph store

let entity = try! decoder.decode(Entity.self, from: data)
```