### PR TITLE
Conformed GraphJSON to Sequence protocol

### DIFF
--- a/Sources/GraphJSON.swift
+++ b/Sources/GraphJSON.swift
@@ -299,3 +299,39 @@ extension GraphJSON: ExpressibleByArrayLiteral {
     self.init(elements)
   }
 }
+
+/**
+ An array iterator for GraphJSON.
+ */
+public struct GraphJSONIterator: IteratorProtocol {
+  /// A reference to the GraphJSON that's being iterated over.
+  let graphJSON: GraphJSON
+  
+  /// Current iteration step.
+  var i = 0
+  
+  /**
+   An initializer accepting GraphJSON object to be iterated over.
+   - Parameter _ graphJSON: A GraphJSON.
+   */
+  init(_ graphJSON: GraphJSON) {
+    self.graphJSON = graphJSON
+  }
+  
+  mutating public func next() -> GraphJSON? {
+    let v = graphJSON[i]
+    
+    guard .isNil != v else {
+      return nil
+    }
+    
+    i += 1
+    return v
+  }
+}
+
+extension GraphJSON: Sequence {
+  public func makeIterator() -> GraphJSONIterator {
+    return GraphJSONIterator(self)
+  }
+}

--- a/Sources/GraphJSON.swift
+++ b/Sources/GraphJSON.swift
@@ -133,8 +133,25 @@ public struct GraphJSON: Equatable, CustomStringConvertible {
   public static func stringify(_ object: Any, options: JSONSerialization.WritingOptions = []) -> String? {
     if let v = object as? GraphJSON {
       return stringify(v.object, options: options)
+    }
     
-    } else if let data = GraphJSON.serialize(object, options: options) {
+    if object is NSNull {
+      return "null"
+    }
+    
+    if let v = object as? String {
+      return v
+    }
+    
+    if let v = object as? Bool {
+      return String(v)
+    }
+    
+    if let v = object as? NSNumber {
+      return v.stringValue
+    }
+    
+    if let data = GraphJSON.serialize(object, options: options) {
       if let v = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as String? {
         return v
       }

--- a/Tests/JSON/GraphJSONTests.swift
+++ b/Tests/JSON/GraphJSONTests.swift
@@ -87,9 +87,16 @@ class GraphJSONTests: XCTestCase {
     XCTAssertEqual(GraphJSON.stringify(true), "true")
   }
   
-  func testEquatable() {
+  func testEquatableAndSequence() {
+    let a = GraphJSON([1, true, "Graph", [:]])
+    let b = GraphJSON([1, true, "Graph", [:]])
+    XCTAssertEqual(a, b)
+    
+    for (left, right) in zip(a, b) {
+      XCTAssertEqual(left, right)
+    }
+    
     XCTAssertEqual(GraphJSON.isNil, .isNil)
-    XCTAssertEqual(GraphJSON([1, true, "Graph", [:]]), GraphJSON([1, true, "Graph", [:]]))
     XCTAssertEqual(GraphJSON(dictionary), GraphJSON(dictionary))
   }
   

--- a/Tests/JSON/GraphJSONTests.swift
+++ b/Tests/JSON/GraphJSONTests.swift
@@ -74,11 +74,17 @@ class GraphJSONTests: XCTestCase {
   }
 
   func testStringify() {
-    XCTAssertNil(GraphJSON.stringify("unsupported top level object"))
+    XCTAssertNil(GraphJSON.stringify(("unsupported top level object", "e.g tuple")))
+    XCTAssertNil(GraphJSON.stringify([("unsupported top level object", "e.g tuple")]))
     XCTAssertEqual(GraphJSON.stringify([]), "[]")
     XCTAssertEqual(GraphJSON.stringify([:]), "{}")
     XCTAssertEqual(GraphJSON.stringify([1, 2, "3", nil, true, false]), "[1,2,\"3\",null,true,false]")
     XCTAssertEqual(GraphJSON.stringify(["user": "orkhan"]), "{\"user\":\"orkhan\"}")
+    
+    XCTAssertEqual(GraphJSON.stringify(NSNull()), "null")
+    XCTAssertEqual(GraphJSON.stringify(1), "1")
+    XCTAssertEqual(GraphJSON.stringify("string"), "string")
+    XCTAssertEqual(GraphJSON.stringify(true), "true")
   }
   
   func testEquatable() {


### PR DESCRIPTION
This allows us to easily iterate over `GraphJSON` array. e.g:

```swift
let json: GraphJSON = ["myArray": [1, true, "test", ["array", 1]]]
for item in json.myArray {
  /// item is of GraphJSON type
  print(item)
}

json.myArray.forEach { //(arrayItem: GraphJSON) in
  print($0)
}

//  json.myArray.map(...
//  json.myArray.reduce(...
```