### PR TITLE
Fixed not compiling with swift 5

### DIFF
--- a/Sources/ManagedNode.swift
+++ b/Sources/ManagedNode.swift
@@ -51,7 +51,7 @@ internal class ManagedNode: ManagedObject {
       } catch let e as NSError {
         fatalError("[Graph Error: Cannot obtain permanent objectID - \(e.localizedDescription)]")
       }
-      return String(stringInterpolationSegment: self.nodeClass) + self.type + self.objectID.uriRepresentation().lastPathComponent
+      return "\(self.nodeClass)" + self.type + self.objectID.uriRepresentation().lastPathComponent
     }
   }
   

--- a/Sources/Predicate.swift
+++ b/Sources/Predicate.swift
@@ -189,7 +189,7 @@ public func <=(left: String, right: NSNumber) -> Predicate {
   return build(left, right, type: .lessThanOrEqualTo)
 }
 
-extension Predicate {
+public extension Predicate {
   /**
    Create a Predicate to filter nodes that have any of
    the properties in the given list.


### PR DESCRIPTION
Fixed breaking change described in #160.

As stated in docs, `String(stringInterpolationSegment:)` should not be used directly and now swift 5 disallows calling it. It was just used to convert an `Int` to `String` in our case. Replaced it with normal string interpolation. Everyone should be happy now.